### PR TITLE
Fix/cargo deny deprecated fields

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -2,19 +2,13 @@
 #   https://embarkstudios.github.io/cargo-deny/index.html
 
 [advisories]
-vulnerability = "deny"
 yanked = "deny"
-unmaintained = "warn"
-notice = "warn"
 ignore = [
 ]
 git-fetch-with-cli = true
 
 [licenses]
-allow-osi-fsf-free = "either"
-copyleft = "warn"
-unlicensed = "deny"
-default = "deny"
+allow = ["Apache-2.0"]
 confidence-threshold = 0.8
 
 

--- a/src/art.rs
+++ b/src/art.rs
@@ -40,7 +40,7 @@ const NODE256MIN: usize = NODE48MAX + 1;
 /// # Fields
 ///
 /// - `node_type`: The `NodeType` variant representing the type of the node, containing its
-///                specific structure and associated data.
+///   specific structure and associated data.
 ///
 pub(crate) struct Node<P: KeyTrait, V: Clone> {
     pub(crate) node_type: NodeType<P, V>, // Type of the node
@@ -1565,7 +1565,7 @@ impl<P: KeyTrait, V: Clone> Tree<P, V> {
     ///
     /// Returns an `Iter` instance that iterates over the key-value pairs in the Trie.
     ///
-    pub fn iter(&self) -> Iter<P, V> {
+    pub fn iter(&self) -> Iter<'_, P, V> {
         Iter::new(self.root.as_ref(), false)
     }
 
@@ -1573,7 +1573,7 @@ impl<P: KeyTrait, V: Clone> Tree<P, V> {
     ///
     /// This function creates and returns an iterator that can be used to traverse all the versions
     /// for all the key-value pairs stored in the Trie. The iterator starts from the root of the Trie.
-    pub fn iter_with_versions(&self) -> Iter<P, V> {
+    pub fn iter_with_versions(&self) -> Iter<'_, P, V> {
         Iter::new(self.root.as_ref(), true)
     }
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1444,7 +1444,7 @@ mod tests {
             .map(|_| {
                 let length = rng.gen_range(length_range.clone());
                 (0..length)
-                    .map(|_| (rng.gen_range(b'a'..=b'z') as char))
+                    .map(|_| rng.gen_range(b'a'..=b'z') as char)
                     .collect()
             })
             .collect()

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -125,7 +125,8 @@ impl<'a, P: KeyTrait + 'a, V: Clone> Iterator for Iter<'a, P, V> {
             self.last_forward_key = Some(leaf.0);
             if self
                 .last_forward_key
-                .zip(self.last_backward_key).is_none_or(|(k1, k2)| k1 < k2)
+                .zip(self.last_backward_key)
+                .is_none_or(|(k1, k2)| k1 < k2)
             {
                 Some((leaf.0.as_slice(), &leaf.1.value, leaf.1.version, leaf.1.ts))
             } else {
@@ -166,7 +167,8 @@ impl<'a, P: KeyTrait + 'a, V: Clone> DoubleEndedIterator for Iter<'a, P, V> {
             self.last_backward_key = Some(leaf.0);
             if self
                 .last_backward_key
-                .zip(self.last_forward_key).is_none_or(|(k1, k2)| k1 > k2)
+                .zip(self.last_forward_key)
+                .is_none_or(|(k1, k2)| k1 > k2)
             {
                 Some((leaf.0.as_slice(), &leaf.1.value, leaf.1.version, leaf.1.ts))
             } else {
@@ -520,7 +522,8 @@ impl<'a, K: KeyTrait + Ord, V: Clone, R: RangeBounds<K>> Iterator for Range<'a, 
             if self
                 .last_forward_key
                 .as_ref()
-                .zip(self.last_backward_key.as_ref()).is_none_or(|(k1, k2)| k1 < k2)
+                .zip(self.last_backward_key.as_ref())
+                .is_none_or(|(k1, k2)| k1 < k2)
             {
                 Some((leaf.0.as_slice(), &leaf.1.value, leaf.1.version, leaf.1.ts))
             } else {
@@ -584,7 +587,8 @@ impl<K: KeyTrait + Ord, V: Clone, R: RangeBounds<K>> DoubleEndedIterator for Ran
             if self
                 .last_backward_key
                 .as_ref()
-                .zip(self.last_forward_key.as_ref()).is_none_or(|(k1, k2)| k1 > k2)
+                .zip(self.last_forward_key.as_ref())
+                .is_none_or(|(k1, k2)| k1 > k2)
             {
                 Some((leaf.0.as_slice(), &leaf.1.value, leaf.1.version, leaf.1.ts))
             } else {


### PR DESCRIPTION
## Quick Summary
Fixes: #89 

The idea is to adapt the `deny.toml` file to work with the new version while keeping the same behavior it had before

Although in the issue I mentioned the idea of using `cd-allow` to add all ofi and fsf licenses into `deny.toml` to keep the same functionality, when implementing I saw that some licenses listed in [SPDX](https://spdx.org/licenses) are not recognized by cargo deny, for example `AFL-1.1`. So as this repo and its dependencies are all below `Apache-2.0` license (at least according to cargo deny), I think it's best to just add it to the configuration file and whenever this change it tackles the problem.

I've also did some format changes recommended by cargo fmt to `src/iter.rs`

## Full Explanation

Here's just a longer explanation of all the fields were dropped and if there's any change because of it

### Advisories

#### vulnerability
It's just gonna deny automatically now, so you won't see any changes in its behavior

#### unmaintained
Since just warning it's not an option now I believe you can let fail if there's any problem and then if it's decided that's shouldn't be flagged the advisory can be added into [ignore](https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html#the-ignore-field-optional) field

#### notice
Same as unmaintained

### Licenses

#### allow-osi-fsf-free
Since you're only below `Apache-2.0` according to cargo deny, I believe it's okay to maintain the `allow` field, and be updating in case you feel like it. There's some licenses listed in [SPDX](https://spdx.org/licenses/) that are not recognized by cargo deny, like `AFL-1.1`.

#### copyleft
Same as `allow-osi-fsf-free`, you're only using `Apache-2.0`

#### unlicensed
The new behavior will deny this by default

#### default
The new version will enforce the behavior you had it configured before


